### PR TITLE
fix: 🐛 system return exit code 3221226356 in 2nd time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/AceofSpades5757/clipboard-win-html"
 
 [dependencies.windows]
 # Windows API
-version = "0.37.0"
+version = "0.54.0"
 features = [
     "Win32_System_DataExchange",
     "Win32_Foundation",


### PR DESCRIPTION
I use this crate in my [Tauri](https://tauri.app/) app.
When I call the function for the second time, the app crashes and returns exit code 3221226356.